### PR TITLE
feat: switch pieces from drag to click movement

### DIFF
--- a/src/components/Pieces/Piece.js
+++ b/src/components/Pieces/Piece.js
@@ -11,15 +11,11 @@ const Piece = ({
     const { appState, dispatch } = useAppContext();
     const { turn, castleDirection, position : currentPosition } = appState
 
-    const onDragStart = e => {
-        e.dataTransfer.effectAllowed = "move";
-        e.dataTransfer.setData("text/plain",`${piece},${rank},${file}`)
-        setTimeout(() => {
-            e.target.style.display = 'none'
-        },0)
+    const onClickPiece = e => {
+        e.stopPropagation();
 
         if (turn === piece[0]){
-            const candidateMoves = 
+            const candidateMoves =
                 arbiter.getValidMoves({
                     position : currentPosition[currentPosition.length - 1],
                     prevPosition : currentPosition[currentPosition.length - 2],
@@ -28,20 +24,15 @@ const Piece = ({
                     file,
                     rank
                 })
-            dispatch(generateCandidates({candidateMoves}))
+            dispatch(generateCandidates({candidateMoves, piece, rank, file}))
         }
 
     }
-    const onDragEnd = e => {
-       e.target.style.display = 'block'
-     }
  
     return (
-        <div 
+        <div
             className={`piece ${piece} p-${file}${rank}`}
-            draggable={true}   
-            onDragStart={onDragStart} 
-            onDragEnd={onDragEnd}
+            onClick={onClickPiece}
 
         />)
 }

--- a/src/components/Pieces/Pieces.js
+++ b/src/components/Pieces/Pieces.js
@@ -47,9 +47,13 @@ const Pieces = () => {
         return {x,y}
     }
 
-    const move = e => {
-        const {x,y} = calculateCoords(e)
-        const [piece,rank,file] = e.dataTransfer.getData("text").split(',')
+    const move = ({x,y}) => {
+        const selected = appState.selectedPiece;
+        if (!selected) {
+            dispatch(clearCandidates());
+            return;
+        }
+        const { piece, rank, file } = selected;
 
         if(appState.candidateMoves.find(m => m[0] === x && m[1] === y)){
             const opponent = piece.startsWith('b') ? 'w' : 'b'
@@ -89,19 +93,15 @@ const Pieces = () => {
         dispatch(clearCandidates())
     }
 
-    const onDrop = e => {
-        e.preventDefault()
-        
-        move (e)
+    const handleClick = e => {
+        const {x,y} = calculateCoords(e)
+        move({x,y})
     }
-    
-    const onDragOver = e => {e.preventDefault()}
 
-    return <div 
-        className='pieces' 
-        ref={ref} 
-        onDrop={onDrop} 
-        onDragOver={onDragOver} > 
+    return <div
+        className='pieces'
+        ref={ref}
+        onClick={handleClick} >
         {currentPosition.map((r,rank) => 
             r.map((f,file) => 
                 currentPosition[rank][file]

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ export const initGameState = {
     position : [createPosition()],
     turn : 'w',
     candidateMoves : [],
+    selectedPiece : null,
     movesList : [],
 
     promotionSquare : null,

--- a/src/reducer/actions/move.js
+++ b/src/reducer/actions/move.js
@@ -13,10 +13,10 @@ export const clearCandidates = () => {
     }
 }
 
-export const generateCandidates = ({candidateMoves}) => {
+export const generateCandidates = ({candidateMoves, piece, rank, file}) => {
     return {
         type: actionTypes.GENERATE_CANDIDATE_MOVES,
-        payload : {candidateMoves}
+        payload : {candidateMoves, piece, rank, file}
     }
 }
 

--- a/src/reducer/reducer.js
+++ b/src/reducer/reducer.js
@@ -24,17 +24,19 @@ export const reducer = (state, action) => {
         }
 
         case actionTypes.GENERATE_CANDIDATE_MOVES : {
-            const {candidateMoves} = action.payload
+            const {candidateMoves, piece, rank, file} = action.payload
             return {
                 ...state,
-                candidateMoves
+                candidateMoves,
+                selectedPiece: { piece, rank, file }
             }
-        } 
+        }
 
         case actionTypes.CLEAR_CANDIDATE_MOVES : {
             return {
                 ...state,
-                candidateMoves : []
+                candidateMoves : [],
+                selectedPiece: null
             }
         }
     


### PR DESCRIPTION
## Summary
- support selecting pieces via click
- move pieces by clicking highlighted squares
- track selected piece in game state

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6894c35ed1988329bce1eb1d0a35b392