### PR TITLE
Correct castling rights lookup for checkmate detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/src/components/Pieces/Pieces.js
+++ b/src/components/Pieces/Pieces.js
@@ -57,7 +57,7 @@ const Pieces = () => {
 
         if(appState.candidateMoves.find(m => m[0] === x && m[1] === y)){
             const opponent = piece.startsWith('b') ? 'w' : 'b'
-            const castleDirection = appState.castleDirection[`${piece.startsWith('b') ? 'white' : 'black'}`]
+            const castleDirection = appState.castleDirection[opponent]
 
             if ((piece==='wp' && x === 7) || (piece==='bp' && x === 0)){
                 openPromotionBox({rank,file,x,y})


### PR DESCRIPTION
## Summary
- fix checkmate logic by reading opponent castling rights using `w`/`b` keys
- add .gitignore for node_modules and package-lock

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6895c3a8b9648329a7893f11ed6cba36